### PR TITLE
Update NGINX and modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ REPO_PATH := github.com/deis/${SHORT_NAME}
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:v0.22.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:v1.10.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}

--- a/model/model.go
+++ b/model/model.go
@@ -3,7 +3,6 @@ package model
 import (
 	"bytes"
 	"encoding/gob"
-	goerrors "errors"
 	"fmt"
 	"log"
 	"strings"
@@ -159,6 +158,7 @@ type AppConfig struct {
 	Locations      []*Location
 }
 
+// Location represents a location block inside a back end server block.
 type Location struct {
 	App  *AppConfig
 	Path string
@@ -172,7 +172,7 @@ func newAppConfig(routerConfig *RouterConfig) (*AppConfig, error) {
 	return &AppConfig{
 		ConnectTimeout: "30s",
 		TCPTimeout:     routerConfig.DefaultTimeout,
-		Certificates:   make(map[string]*Certificate, 0),
+		Certificates:   make(map[string]*Certificate),
 		SSLConfig:      newSSLConfig(),
 		Nginx:          nginxConfig,
 	}, nil
@@ -436,7 +436,7 @@ func linkLocations(appConfigs []*AppConfig) error {
 		if app.ProxyDomain != "" && len(app.ProxyLocations) > 0 {
 			targetApp := appByDomain(appConfigs, app.ProxyDomain)
 			if targetApp == nil {
-				return goerrors.New(fmt.Sprintf("Can't find ProxyDomain '%s' in any application", app.ProxyDomain))
+				return fmt.Errorf("Can't find ProxyDomain '%s' in any application", app.ProxyDomain)
 			}
 
 			for _, loc := range app.ProxyLocations {

--- a/nginx/config_test.go
+++ b/nginx/config_test.go
@@ -183,7 +183,7 @@ func TestWriteConfig(t *testing.T) {
 	WriteConfig(&routerConfig, tmpFile.Name())
 
 	if _, err := os.Stat(tmpFile.Name()); os.IsNotExist(err) {
-		t.Errorf("Expected to find nginx config file. No file found.")
+		t.Errorf("Expected to find nginx config file. No file found")
 	}
 }
 
@@ -194,7 +194,7 @@ func checkCertAndKey(crtPath string, keyPath string, expectedCertContents string
 	}
 
 	if !reflect.DeepEqual(expectedCertContents, string(actualCertContents)) {
-		return fmt.Errorf("Expected test.crt contents, %s, does not match actual contents, %s.", expectedCertContents, string(actualCertContents))
+		return fmt.Errorf("Expected test.crt contents, %s, does not match actual contents, %s", expectedCertContents, string(actualCertContents))
 	}
 
 	actualKeyContents, err := ioutil.ReadFile(keyPath)
@@ -202,7 +202,7 @@ func checkCertAndKey(crtPath string, keyPath string, expectedCertContents string
 		return err
 	}
 	if !reflect.DeepEqual(expectedKeyContents, string(actualKeyContents)) {
-		return fmt.Errorf("Expected test.key contents, %s, does not match actual contents, %s.", expectedKeyContents, string(actualKeyContents))
+		return fmt.Errorf("Expected test.key contents, %s, does not match actual contents, %s", expectedKeyContents, string(actualKeyContents))
 	}
 
 	expectedCertPerm := "-rw-r--r--" // 0644
@@ -211,13 +211,13 @@ func checkCertAndKey(crtPath string, keyPath string, expectedCertContents string
 	crtInfo, _ := os.Stat(crtPath)
 	actualCertPerm := crtInfo.Mode().String()
 	if !reflect.DeepEqual(expectedCertPerm, actualCertPerm) {
-		return fmt.Errorf("Expected permission on test.crt, %s, does not match actual, %s.", expectedCertPerm, actualCertPerm)
+		return fmt.Errorf("Expected permission on test.crt, %s, does not match actual, %s", expectedCertPerm, actualCertPerm)
 	}
 
 	keyInfo, _ := os.Stat(keyPath)
 	actualKeyPerm := keyInfo.Mode().String()
 	if !reflect.DeepEqual(expectedKeyPerm, actualKeyPerm) {
-		return fmt.Errorf("Expected permission on test.key, %s, does not match actual, %s.", expectedKeyPerm, actualKeyPerm)
+		return fmt.Errorf("Expected permission on test.key, %s, does not match actual, %s", expectedKeyPerm, actualKeyPerm)
 	}
 
 	return nil

--- a/rootfs/.dockerignore
+++ b/rootfs/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,13 +14,13 @@ RUN buildDeps='gcc make apt-utils libgeoip-dev libssl-dev libpcre3-dev'; \
     apt-get install -y --no-install-recommends \
         $buildDeps \
         libgeoip1 && \
-    export NGINX_VERSION=1.13.7 SIGNING_KEY=A1C052F8 VTS_VERSION=0.1.10 BUILD_PATH=/tmp/build PREFIX=/opt/router && \
+    export NGINX_VERSION=1.14.2 SIGNING_KEY=A1C052F8 VTS_VERSION=0.1.18 BUILD_PATH=/tmp/build PREFIX=/opt/router && \
     rm -rf "$PREFIX" && \
     mkdir "$PREFIX" && \
     mkdir "$BUILD_PATH" && \
     cd "$BUILD_PATH" && \
     get_src_gpg $SIGNING_KEY "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz" && \
-    get_src c6f3733e9ff84bfcdc6bfb07e1baf59e72c4e272f06964dd0ed3a1bdc93fa0ca "https://github.com/vozlt/nginx-module-vts/archive/v$VTS_VERSION.tar.gz" && \
+    get_src 17ea41d4083f6d1ab1ab83dad9160eeca66867abe16c5a0421f85a39d7c84b65 "https://github.com/vozlt/nginx-module-vts/archive/v$VTS_VERSION.tar.gz" && \
     cd "$BUILD_PATH/nginx-$NGINX_VERSION" && \
     ./configure \
       --prefix="$PREFIX" \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,3 +1,37 @@
+FROM quay.io/deis/base:v0.3.6 as modsecurity
+
+COPY /bin /bin
+WORKDIR /tmp/build
+
+RUN set -x && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        g++ make \
+        libcurl4-openssl-dev \
+        libyajl-dev \
+        liblmdb-dev \
+        libxml2-dev \
+        libpcre3-dev \
+        libmaxminddb-dev \
+        libfuzzy-dev && \
+    export MOD_SECURITY_VERSION=3.0.3 BUILD_PATH=$PWD PREFIX=/usr/local && \
+    get_src 8aa1300105d8cc23315a5e54421192bc617a66246ad004bd89e67c232208d0f4 \
+            "https://github.com/SpiderLabs/ModSecurity/releases/download/v$MOD_SECURITY_VERSION/modsecurity-v$MOD_SECURITY_VERSION.tar.gz" && \
+    cd "$BUILD_PATH/modsecurity-v$MOD_SECURITY_VERSION" && \
+    ./configure \
+      --prefix="$PREFIX" \
+      --enable-silent-rules \
+      --enable-static=no \
+      --disable-doxygen-doc \
+      --disable-examples \
+      --disable-dependency-tracking && \
+    make -j`nproc` && \
+    make install-strip && \
+    install -D -m 644 -t "$PREFIX/share/modsecurity" \
+        unicode.mapping \
+        modsecurity.conf-recommended
+
+
 FROM quay.io/deis/base:v0.3.6
 
 RUN adduser --system \
@@ -7,20 +41,33 @@ RUN adduser --system \
 	--group \
 	router
 
+COPY --from=modsecurity /usr/local /usr/local
+
 COPY /bin /bin
 
-RUN buildDeps='gcc make apt-utils libgeoip-dev libssl-dev libpcre3-dev'; \
+RUN set -x && \
+    buildDeps='gcc make apt-utils libgeoip-dev libmaxminddb-dev libssl-dev libpcre3-dev' \
+    runtimeDeps='libcurl3 libxml2 libpcre3 libgeoip1 libmaxminddb0 libfuzzy2 openssl' && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         $buildDeps \
-        libgeoip1 && \
-    export NGINX_VERSION=1.14.2 SIGNING_KEY=A1C052F8 VTS_VERSION=0.1.18 BUILD_PATH=/tmp/build PREFIX=/opt/router && \
+        $runtimeDeps && \
+    export NGINX_VERSION=1.14.2 SIGNING_KEY=A1C052F8 \
+           VTS_VERSION=0.1.18 GEOIP2_VERSION=3.2 \
+           MOD_SECURITY_NGINX_VERSION=d7101e13685efd7e7c9f808871b202656a969f4b \
+           OWASP_MOD_SECURITY_CRS_VERSION=46171c0ef335f92b26787ce269e397c480286155 \
+           BUILD_PATH=/tmp/build PREFIX=/opt/router && \
     rm -rf "$PREFIX" && \
     mkdir "$PREFIX" && \
     mkdir "$BUILD_PATH" && \
     cd "$BUILD_PATH" && \
     get_src_gpg $SIGNING_KEY "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz" && \
-    get_src 17ea41d4083f6d1ab1ab83dad9160eeca66867abe16c5a0421f85a39d7c84b65 "https://github.com/vozlt/nginx-module-vts/archive/v$VTS_VERSION.tar.gz" && \
+    get_src 17ea41d4083f6d1ab1ab83dad9160eeca66867abe16c5a0421f85a39d7c84b65 \
+            "https://github.com/vozlt/nginx-module-vts/archive/v$VTS_VERSION.tar.gz" && \
+    get_src 15bd1005228cf2c869a6f09e8c41a6aaa6846e4936c473106786ae8ac860fab7 \
+            "https://github.com/leev/ngx_http_geoip2_module/archive/$GEOIP2_VERSION.tar.gz" && \
+    get_src 5c8d25e68fb852f61489b669aebb7bd8ca8c88ebb5e5f969212fcceff3ee2d0b \
+            "https://github.com/SpiderLabs/ModSecurity-nginx/archive/$MOD_SECURITY_NGINX_VERSION.tar.gz" && \
     cd "$BUILD_PATH/nginx-$NGINX_VERSION" && \
     ./configure \
       --prefix="$PREFIX" \
@@ -36,48 +83,43 @@ RUN buildDeps='gcc make apt-utils libgeoip-dev libssl-dev libpcre3-dev'; \
       --with-http_dav_module \
       --with-http_geoip_module \
       --with-http_gzip_static_module \
+      --with-http_gunzip_module \
       --with-http_sub_module \
       --with-http_v2_module \
       --with-mail \
       --with-mail_ssl_module \
       --with-stream \
-      --add-module="$BUILD_PATH/nginx-module-vts-$VTS_VERSION" && \
-    make && \
+      --add-module="$BUILD_PATH/nginx-module-vts-$VTS_VERSION" \
+      --add-dynamic-module="$BUILD_PATH/ngx_http_geoip2_module-$GEOIP2_VERSION" \
+      --add-dynamic-module="$BUILD_PATH/ModSecurity-nginx-$MOD_SECURITY_NGINX_VERSION" && \
+    make -j`nproc` && \
     make install && \
-    rm -rf "$BUILD_PATH" && \
-    # include tcell dynamic nginx module
-    mkdir "$PREFIX/modules" && \
-    cd "$PREFIX/modules" && \
-    get_src 8f30a4d5f4a65e1a94c367b98cfec33e727453a7e7ffc7e85094a0e7a561f72d "https://s3.amazonaws.com/hephy-artifacts/hephy-router/nginx_tcellagent-1.1.0-agentonly-zuora-linux-x86_64.tar.gz" && \
-    mv "$PREFIX/modules/nginx_tcellagent-1.1.0-agentonly-zuora-linux-x86_64/ubuntu/xenial/nginx-1.13.7-custom_flags_ssl_1.0.2g/ngx_http_tcell_agent_module.so" . && \
-    rm -rf "$PREFIX/modules/nginx_tcellagent-1.1.0-agentonly-zuora-linux-x86_64" && \
-    # include libmodsecurity3 and modsecurity connector dynamic module
-    modsecurityDeps='apt-utils git libcurl4-openssl-dev libyajl-dev libxml2 libxml2-dev' && \
-    apt-get install -y --no-install-recommends \
-        $modsecurityDeps && \
-    cd "$PREFIX/modules" && \
-    get_src 136e0faf4b313817abd07365935ebd9174e8754700fe8a06281dbcbbe6d0ad50 "https://s3.amazonaws.com/hephy-artifacts/hephy-router/modsecurity-v3.0.3-ubuntu-16-04.tar.gz" && \
-    mv usr/local/modsecurity /usr/local/modsecurity && \
-    rm -rf usr && \
-    get_src_file c9fd4ddb69ba1ce0a3118e529c43f87c3ab216e20900e25863e58537399d2d19 "https://s3.amazonaws.com/hephy-artifacts/hephy-router/ngx_http_modsecurity_module.so" && \
+    strip -s "$PREFIX/sbin/nginx" "$PREFIX/modules/"*.so && \
+    cd "$BUILD_PATH" && \
     # setup the modsecurity config and OWASP rules
-    cd "$PREFIX/conf" && \
-    get_src_file 5614fd0f68fc7707c0dc008d45b92de586b6e14937a41b93e80165aec454eecd "https://s3.amazonaws.com/hephy-artifacts/hephy-router/modsecurity.conf" && \
-    curl -sSL https://github.com/SpiderLabs/ModSecurity/raw/v3/master/unicode.mapping -o unicode.mapping && \
-    git clone https://github.com/SpiderLabs/owasp-modsecurity-crs.git && \
-    cp -R owasp-modsecurity-crs/rules/ $PREFIX/conf/ && \
-    cp $PREFIX/conf/owasp-modsecurity-crs/crs-setup.conf.example $PREFIX/conf/crs-setup.conf && \
-    rm -rf owasp-modsecurity-crs && \
+    get_src c0e5d496db41b9b5e201fd8138e2507d22b22cf945b7b06bf3c9fad31b0bba95 \
+            "https://github.com/SpiderLabs/owasp-modsecurity-crs/archive/$OWASP_MOD_SECURITY_CRS_VERSION.tar.gz" && \
+    cp -R owasp-modsecurity-crs-$OWASP_MOD_SECURITY_CRS_VERSION/rules $PREFIX/conf/ && \
+    cp owasp-modsecurity-crs-$OWASP_MOD_SECURITY_CRS_VERSION/crs-setup.conf.example $PREFIX/conf/crs-setup.conf && \
+    cp /usr/local/share/modsecurity/unicode.mapping "$PREFIX/conf/" && \
+    sed -e 's/^SecRuleEngine DetectionOnly/SecRuleEngine On/' \
+        -e '$ a # Load OWASP Core Rule Set' \
+        -e '$ a Include crs-setup.conf' \
+        -e '$ a Include rules/*.conf' \
+        /usr/local/share/modsecurity/modsecurity.conf-recommended > "$PREFIX/conf/modsecurity.conf" && \
+    cd / && \
+    rm -rf "$BUILD_PATH" && \
+    rm -rf /usr/local/include/* && \
     # cleanup
     apt-get purge -y --auto-remove $buildDeps && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     # package up license files if any by appending to existing tar
-    COPYRIGHT_TAR='/usr/share/copyrights.tar'; \
-    gunzip -f $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
+    COPYRIGHT_TAR='/usr/share/copyrights.tar' && \
+    gunzip -f $COPYRIGHT_TAR.gz && tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright && gzip $COPYRIGHT_TAR && \
     rm -rf \
         /usr/share/doc \
-        /usr/share/man \
+        /usr/share/man/man?/* \
         /usr/share/info \
         /usr/share/locale \
         /var/lib/apt/lists/* \
@@ -87,8 +129,7 @@ RUN buildDeps='gcc make apt-utils libgeoip-dev libssl-dev libpcre3-dev'; \
         /lib/lsb \
         /lib/udev \
         /usr/lib/x86_64-linux-gnu/gconv/IBM* \
-        /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
-    bash -c "mkdir -p /usr/share/man/man{1..8}"
+        /usr/lib/x86_64-linux-gnu/gconv/EBC*
 
 COPY . /
 

--- a/utils/modeler/modeler.go
+++ b/utils/modeler/modeler.go
@@ -134,7 +134,7 @@ func (m *Modeler) mapToModel(data map[string]string, context string, rv reflect.
 					}
 					elem.Field(i).Set(reflect.ValueOf(mapVal))
 				} else {
-					return fmt.Errorf("Unsupported type %s.", rf.Type.Kind())
+					return fmt.Errorf("Unsupported type %s", rf.Type.Kind())
 				}
 			}
 		}

--- a/utils/modeler/modeler_test.go
+++ b/utils/modeler/modeler_test.go
@@ -15,8 +15,8 @@ const (
 )
 
 var (
-	sampleData        = make(map[string]string, 0)
-	invalidSampleData = make(map[string]string, 0)
+	sampleData        = make(map[string]string)
+	invalidSampleData = make(map[string]string)
 	m                 = NewModeler(prefix, fieldTag, constraintTag, false)
 )
 


### PR DESCRIPTION
* Update to NGINX 1.14.2 – notable changes since 1.13.7:
  - [HTTP/2 server push support](https://www.nginx.com/blog/nginx-1-13-9-http2-server-push/)  (we should add an annotation to enable `http2_push_preload`)
  - Support for the binary  PROXY protocol v2 in the `proxy_protocol` directive (this is required for using PROXY protocol with AWS Network Load Balancer. Classic ELB uses the plaintext v1 protocol.)
  - Fixes [CVE-2018-16843](https://nvd.nist.gov/vuln/detail/CVE-2018-16843) and [CVE-2018-16844](https://nvd.nist.gov/vuln/detail/CVE-2018-16844) DoS attacks via HTTP/2
* Update VTS module to 0.1.18 (lots of [crash-fixes](https://github.com/vozlt/nginx-module-vts/blob/master/Changes))
* Update to last go-dev image based on deis/base image (go 1.7 -> 1.10)
* Don't bake Dockerfile into image
* Remove external binaries, use multi-stage build
  - libmodsecurity 3.0.3 is built in a separate stage
  - remove proprietary tcell nginx ext
  - remove precompiled modsecurity binaries
  - add geoip2 module (because geoip is deprecated)
  - add gunzip core module (useful if proxying precompressed assets)
  - update OWASP mod security core ruleset to latest 3.2/dev
  - remove external configs from s3, copy or modify templates
  - fix some uncaught errors in build script that could lead
    to corrupted images, because a failure would not set
    an error exit code
  - log all shell commands via `set -x`
  - speed up make by using parallel jobs based on cpu cores (`nproc`)
