### PR TITLE
feat(k8s.io): upgrade to using appv1, corev1, metav1 in router

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,237 @@
-hash: 52c0d9085bf858c0c4720d0dde6492f6cfc609bb6e42fa72a6fa59eb7a8e0146
-updated: 2016-09-23T10:13:55.229822854-07:00
+hash: 60b3058ba49c1548ed33ec30fd8743c28c0bc806de57bf3698a92e78fbcb8371
+updated: 2020-09-26T20:33:34.362050949-04:00
 imports:
 - name: github.com/aokoli/goutils
-  version: 9c37978a95bd5c709a15883b6242714ea6709e64
+  version: 864fea799ab6516ec883dc052a9a0b15f1e529dd
+- name: github.com/davecgh/go-spew
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
+  subpackages:
+  - spew
+- name: github.com/gogo/protobuf
+  version: 65acae22fc9d1fe290b33faa2bd64cdc20a463a0
+  subpackages:
+  - proto
+  - sortkeys
+- name: github.com/golang/protobuf
+  version: 6c65a5562fc06764971b7c5d05c76c75e84bdbf7
+  subpackages:
+  - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
+- name: github.com/google/gofuzz
+  version: f140a6486e521aad38f5917de355cbf147cc0496
+- name: github.com/googleapis/gnostic
+  version: 0c5108395e2debce0d731cf0287ddf7242066aba
+  subpackages:
+  - OpenAPIv2
+  - compiler
+  - extensions
+- name: github.com/json-iterator/go
+  version: 03217c3e97663914aec3faafde50d081f197a0a2
 - name: github.com/Masterminds/sprig
   version: 2493695b1e81bd6ef2ac18d2591fcf46725e5a50
-- name: k8s.io/client-go
-  version: 0b62e254fe853d89b1d8d3445bbdab11bcc11bc3
+- name: github.com/modern-go/concurrent
+  version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
+- name: github.com/modern-go/reflect2
+  version: 94122c33edd36123c84d5368cfb2b69df93a0ec8
+- name: golang.org/x/crypto
+  version: bac4c82f69751a6dd76e702d54b3ceb88adab236
   subpackages:
-  - "1.4"
+  - ssh/terminal
+- name: golang.org/x/net
+  version: 13f9640d40b9cc418fb53703dfbd177679788ceb
+  subpackages:
+  - context
+  - context/ctxhttp
+  - http/httpguts
+  - http2
+  - http2/hpack
+  - idna
+- name: golang.org/x/oauth2
+  version: 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
+  subpackages:
+  - internal
+- name: golang.org/x/sys
+  version: fde4db37ae7ad8191b03d30d27f258b5291ae4e3
+  subpackages:
+  - unix
+  - windows
+- name: golang.org/x/text
+  version: 342b2e1fbaa52c93f31447ad2c6abc048c63e475
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: golang.org/x/time
+  version: 9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
+  subpackages:
+  - rate
+- name: google.golang.org/appengine
+  version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
+  subpackages:
+  - internal
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
+- name: gopkg.in/inf.v0
+  version: d2d2541c53f18d2a059457998ce2876cc8e67cbf
+- name: gopkg.in/yaml.v2
+  version: 53403b58ad1b561927d19068c655246f2db79d48
+- name: k8s.io/api
+  version: f4b723619c714d98e1fa4f26bc89db56550b7794
+  subpackages:
+  - admissionregistration/v1
+  - admissionregistration/v1beta1
+  - apps/v1
+  - apps/v1beta1
+  - apps/v1beta2
+  - auditregistration/v1alpha1
+  - authentication/v1
+  - authentication/v1beta1
+  - authorization/v1
+  - authorization/v1beta1
+  - autoscaling/v1
+  - autoscaling/v2beta1
+  - autoscaling/v2beta2
+  - batch/v1
+  - batch/v1beta1
+  - batch/v2alpha1
+  - certificates/v1beta1
+  - coordination/v1
+  - coordination/v1beta1
+  - core/v1
+  - discovery/v1alpha1
+  - discovery/v1beta1
+  - events/v1beta1
+  - extensions/v1beta1
+  - flowcontrol/v1alpha1
+  - networking/v1
+  - networking/v1beta1
+  - node/v1alpha1
+  - node/v1beta1
+  - policy/v1beta1
+  - rbac/v1
+  - rbac/v1alpha1
+  - rbac/v1beta1
+  - scheduling/v1
+  - scheduling/v1alpha1
+  - scheduling/v1beta1
+  - settings/v1alpha1
+  - storage/v1
+  - storage/v1alpha1
+  - storage/v1beta1
+- name: k8s.io/apimachinery
+  version: e01b6f647e0d5357a0d3da5426b40ee055b9430a
+  subpackages:
+  - pkg/api/errors
+  - pkg/api/meta
+  - pkg/api/resource
+  - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/types
+  - pkg/util/clock
+  - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/naming
+  - pkg/util/net
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - third_party/forked/golang/reflect
+- name: k8s.io/client-go
+  version: 92dd56df9ae8a81e3343773810c1e4a61303659d
+  subpackages:
+  - discovery
+  - kubernetes
+  - kubernetes/scheme
+  - kubernetes/typed/admissionregistration/v1
+  - kubernetes/typed/admissionregistration/v1beta1
+  - kubernetes/typed/apps/v1
+  - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/apps/v1beta2
+  - kubernetes/typed/auditregistration/v1alpha1
+  - kubernetes/typed/authentication/v1
+  - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authorization/v1
+  - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/autoscaling/v2beta1
+  - kubernetes/typed/autoscaling/v2beta2
+  - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v1beta1
+  - kubernetes/typed/batch/v2alpha1
+  - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/coordination/v1
+  - kubernetes/typed/coordination/v1beta1
+  - kubernetes/typed/core/v1
+  - kubernetes/typed/discovery/v1alpha1
+  - kubernetes/typed/discovery/v1beta1
+  - kubernetes/typed/events/v1beta1
+  - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/flowcontrol/v1alpha1
+  - kubernetes/typed/networking/v1
+  - kubernetes/typed/networking/v1beta1
+  - kubernetes/typed/node/v1alpha1
+  - kubernetes/typed/node/v1beta1
+  - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/rbac/v1
+  - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/scheduling/v1
+  - kubernetes/typed/scheduling/v1alpha1
+  - kubernetes/typed/scheduling/v1beta1
+  - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1alpha1
+  - kubernetes/typed/storage/v1beta1
+  - pkg/apis/clientauthentication
+  - pkg/apis/clientauthentication/v1alpha1
+  - pkg/apis/clientauthentication/v1beta1
+  - pkg/version
+  - plugin/pkg/client/auth/exec
+  - rest
+  - rest/watch
+  - tools/clientcmd/api
+  - tools/metrics
+  - tools/reference
+  - transport
+  - util/cert
+  - util/connrotation
+  - util/flowcontrol
+  - util/keyutil
+- name: k8s.io/klog
+  version: 2ca9ad30301bf30a8a6e0fa2110db6b8df699a91
+- name: k8s.io/utils
+  version: e782cd3c129fc98ee807f3c889c0f26eb7c9daf5
+  subpackages:
+  - integer
+- name: sigs.k8s.io/yaml
+  version: fd68e9863619f6ec2fdd8625fe1f02e7c877e480
 - name: speter.net/go/exp/math/dec/inf
   version: 46a40649338836f5d25521ce343379da79ef2184
   repo: https://github.com/belua/inf

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,8 +3,8 @@ flatten: true
 ignore:
   - k8s.io/kubernetes
 import:
-- package: k8s.io/client-go/1.4
-  version: 0b62e254fe853d89b1d8d3445bbdab11bcc11bc3
+- package: k8s.io/client-go
+  version: release-14.0
 - package: github.com/Masterminds/sprig
   version: ~1.1
 - package: speter.net/go/exp/math/dec/inf

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -4,9 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/client-go/1.4/pkg/api/v1"
-	"k8s.io/client-go/1.4/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/1.4/pkg/util/intstr"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -20,8 +21,8 @@ const (
 func TestBuildRouterConfig(t *testing.T) {
 	// Ensure a valid Router Deployment, Platform Cert, and DHParam result in the expected RouterConfig.
 	replicas := int32(1)
-	routerDeployment := v1beta1.Deployment{
-		ObjectMeta: v1.ObjectMeta{
+	routerDeployment := appv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      routerName,
 			Namespace: deisNamespace,
 			Annotations: map[string]string{
@@ -34,21 +35,21 @@ func TestBuildRouterConfig(t *testing.T) {
 				"heritage": "deis",
 			},
 		},
-		Spec: v1beta1.DeploymentSpec{
-			Strategy: v1beta1.DeploymentStrategy{
-				Type:          v1beta1.RollingUpdateDeploymentStrategyType,
-				RollingUpdate: &v1beta1.RollingUpdateDeployment{},
+		Spec: appv1.DeploymentSpec{
+			Strategy: appv1.DeploymentStrategy{
+				Type:          appv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appv1.RollingUpdateDeployment{},
 			},
 			Replicas: &replicas,
-			Selector: &v1beta1.LabelSelector{MatchLabels: map[string]string{"app": routerName}},
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: v1.ObjectMeta{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": routerName}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": routerName,
 					},
 				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
 							Image: "deis/router",
 						},
@@ -58,27 +59,27 @@ func TestBuildRouterConfig(t *testing.T) {
 		},
 	}
 
-	platformCertSecret := v1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+	platformCertSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      platformCertName,
 			Namespace: deisNamespace,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"tls.crt": []byte("foo"),
 			"tls.key": []byte("bar"),
 		},
 	}
 
-	dhParamSecret := v1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+	dhParamSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      dhParamName,
 			Namespace: deisNamespace,
 			Labels: map[string]string{
 				"heritage": "deis",
 			},
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"dhparam": []byte("bizbaz"),
 		},
@@ -128,8 +129,8 @@ func TestBuildRouterConfig(t *testing.T) {
 
 func TestBuildBuilderConfig(t *testing.T) {
 	// Ensure a Builder Service with annotations returns the expected BuilderConfig.
-	builderService := v1.Service{
-		ObjectMeta: v1.ObjectMeta{
+	builderService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      builderName,
 			Namespace: deisNamespace,
 			Labels: map[string]string{
@@ -139,8 +140,8 @@ func TestBuildBuilderConfig(t *testing.T) {
 				"router.deis.io/nginx.connectTimeout": "20s",
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
 				{
 					Name: "ssh",
 					Port: int32(2222),
@@ -183,12 +184,12 @@ func TestBuildBuilderConfig(t *testing.T) {
 
 func TestBuildCertificate(t *testing.T) {
 	// Ensure a valid Cert Secret returns the expected certificate.
-	validCertSecret := v1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+	validCertSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      platformCertName,
 			Namespace: deisNamespace,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"tls.crt": []byte("foo"),
 			"tls.key": []byte("bar"),
@@ -209,12 +210,12 @@ func TestBuildCertificate(t *testing.T) {
 	}
 
 	// Ensure an invalid Cert Secret returns nil.
-	invalidCertSecret := v1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+	invalidCertSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      platformCertName,
 			Namespace: deisNamespace,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"a": []byte("foo"),
 			"b": []byte("bar"),
@@ -233,12 +234,12 @@ func TestBuildCertificate(t *testing.T) {
 func TestBuildDHParam(t *testing.T) {
 	// Ensure a valid DHParam Secret returns the expected DHParam string.
 	expectedDHParam := "bizbaz"
-	dhParamSecret := v1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+	dhParamSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      dhParamName,
 			Namespace: deisNamespace,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"dhparam": []byte(expectedDHParam),
 		},
@@ -253,12 +254,12 @@ func TestBuildDHParam(t *testing.T) {
 	}
 
 	// Ensure an invalid DHParam Secret returns an empty string.
-	invalidDHParamSecret := v1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+	invalidDHParamSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      dhParamName,
 			Namespace: deisNamespace,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"foo": []byte("bar"),
 		},

--- a/router.go
+++ b/router.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/teamhephy/router/model"
 	"github.com/teamhephy/router/nginx"
-	"k8s.io/client-go/1.4/kubernetes"
-	"k8s.io/client-go/1.4/pkg/util/flowcontrol"
-	"k8s.io/client-go/1.4/rest"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 )
 
 func main() {


### PR DESCRIPTION
Upgrade to k8s.io/client-go release-14.0 branch. (Can probably upgrade up to release-1.19 branch soon)
Upgrade the clients and api objects in router to appv1, corev1, metav1.

All test pass locally so far. Have not tested making an image and running in a cluster yet.