### PR TITLE
feat(router): add Kubernetes rate limit through environment variables for configuration computation/reload #59

### DIFF
--- a/router.go
+++ b/router.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"reflect"
+	"os"
+	"strconv"
 
 	"github.com/teamhephy/router/model"
 	"github.com/teamhephy/router/nginx"
@@ -16,6 +18,14 @@ func main() {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		log.Fatalf("Failed to create config: %v", err)
+	}
+	if qps, err := strconv.ParseFloat(os.Getenv("RATE_LIMIT_QPS"), 32); err == nil {
+		cfg.QPS = float32(qps)
+		log.Printf("INFO: Setting QPS %f\n", qps)
+	}
+	if burst, err := strconv.Atoi(os.Getenv("RATE_LIMIT_BURST")); err == nil {
+		cfg.Burst = burst
+		log.Printf("INFO: Setting Burst %d\n", burst)
 	}
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {

--- a/router.go
+++ b/router.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"log"
-	"reflect"
 	"os"
+	"reflect"
 	"strconv"
 
 	"github.com/teamhephy/router/model"


### PR DESCRIPTION
This PR introduces the environment variables named `RATE_LIMIT_QPS` and `RATE_LIMIT_BURST` that can configure the `cfg.QPS` and `cfg.Burst` of the used [Config](https://pkg.go.dev/k8s.io/client-go@v0.21.1/rest#Config). They are meant to be set on the deployment level so that the pods may get them.

If the variables are not set they will default to `""` and thus won't pass the check `err == nil`, which means that the default settings will be used. This PR tries to fix the issue [59](https://github.com/teamhephy/router/issues/59).