### PR TITLE
feat(router): add helm chart variables for rate_limit.qps and rate_limit.burst #59

### DIFF
--- a/charts/router/templates/router-deployment.yaml
+++ b/charts/router/templates/router-deployment.yaml
@@ -60,6 +60,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+{{- if (.Values.rate_limit.qps) }}
+        - name: RATE_LIMIT_QPS
+          value: {{.Values.rate_limit.qps}}
+{{- end}}
+{{- if (.Values.rate_limit.burst) }}
+        - name: RATE_LIMIT_BURST
+          value: {{.Values.rate_limit.burst}}
+{{- end}}
         ports:
         - containerPort: 8080
 {{- if .Values.host_port.enabled }}

--- a/charts/router/values.yaml
+++ b/charts/router/values.yaml
@@ -7,6 +7,9 @@ dhparam: ""
 # limits_memory: "50Mi"
 # requests_cpu: "100m"
 # requests_memory: "50Mi"
+# rate_limit:
+#   qps: "50.0"
+#   burst: "50"
 
 # Any custom router annotations(https://github.com/teamhephy/router#annotations)
 # which need to be applied can be specified as key-value pairs under "deployment_annotations"


### PR DESCRIPTION
This PR introduces the helm chart variables for setting the `RATE_LIMIT_QPS` and `RATE_LIMIT_BURST` in the deployment. 

closes #59 